### PR TITLE
Fix ServerCfg for optional endpoint

### DIFF
--- a/common/cfg.py
+++ b/common/cfg.py
@@ -24,6 +24,10 @@ class MonitoringCfg:
 @dataclass
 class ServerCfg:
     port: int = 8000
+    # Optional base endpoint prefix. Unused by the current server
+    # implementation but tolerated in configuration files for
+    # forward compatibility.
+    endpoint: str | None = None
 
 @dataclass
 class ServerFullCfg:


### PR DESCRIPTION
## Summary
- allow `endpoint` in server YAML config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68737709e714832091e88a6f4d64cf74