### PR TITLE
Add chat UI to simulator server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Two components:
 
 1. **agent/** – LangGraph-based ReAct agent that tries to exfiltrate the *flag*.
 2. **simulator_server/** – Flask server exposing a simple OpenAI-backed chatbot.
-   Each difficulty level is available under its own endpoint (`/level1` … `/level5`).
+   Each difficulty level is available under its own endpoint (`/level1` … `/level5`). Visiting `/`
+   serves a tiny web UI where you can chat with the LLM and pick the difficulty level.
    A health check endpoint (`/health`) returns `{"status": "ok"}`.
 
 ## Quick start

--- a/simulator_server/server.py
+++ b/simulator_server/server.py
@@ -1,6 +1,6 @@
 """Simple Flask server wrapping an OpenAI LLM."""
 
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_from_directory
 import argparse
 from functools import partial
 from typing import Callable
@@ -39,8 +39,12 @@ def create_app(cfg) -> Flask:
         api_key=cfg.model_config.api_key,
     )
 
-    app = Flask(__name__)
+    app = Flask(__name__, static_folder="static")
     app.add_url_rule("/health", "health", health, methods=["GET"])
+
+    @app.route("/")
+    def index():
+        return send_from_directory(app.static_folder, "index.html")
 
     def _call_llm(system_prompt: str, user_prompt: str) -> str:
         """Call the LLM with retries and error handling."""

--- a/simulator_server/static/index.html
+++ b/simulator_server/static/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>LLM Chat</title>
+<style>
+#chat { border: 1px solid #ccc; padding: 5px; height: 200px; overflow-y: scroll; }
+</style>
+</head>
+<body>
+<select id="level">
+  <option value="level1">Level 1</option>
+  <option value="level2">Level 2</option>
+  <option value="level3">Level 3</option>
+  <option value="level4">Level 4</option>
+  <option value="level5">Level 5</option>
+</select>
+<div id="chat"></div>
+<input type="text" id="msg" placeholder="Type your message"/>
+<button id="send">Send</button>
+<script>
+document.getElementById('send').onclick = async () => {
+  const level = document.getElementById('level').value;
+  const input = document.getElementById('msg');
+  const message = input.value;
+  if (!message) return;
+  const chat = document.getElementById('chat');
+  chat.innerHTML += '<div><b>You:</b> ' + message + '</div>';
+  input.value = '';
+  try {
+    const resp = await fetch('/' + level, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message })
+    });
+    const data = await resp.json();
+    chat.innerHTML += '<div><b>LLM:</b> ' + (data.answer || data.error) + '</div>';
+    chat.scrollTop = chat.scrollHeight;
+  } catch (err) {
+    chat.innerHTML += '<div><b>Error:</b> ' + err + '</div>';
+  }
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple HTML page served from `/` for chatting with the LLM
- expose static directory from the Flask app
- document the new UI in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6873a92f131c8320b40cfddb58d324fc