### PR TITLE
Enhance chat UI with external CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Two components:
 
 1. **agent/** – LangGraph-based ReAct agent that tries to exfiltrate the *flag*.
 2. **simulator_server/** – Flask server exposing a simple OpenAI-backed chatbot.
-   Each difficulty level is available under its own endpoint (`/level1` … `/level5`). Visiting `/`
-   serves a tiny web UI where you can chat with the LLM and pick the difficulty level.
+  Each difficulty level is available under its own endpoint (`/level1` … `/level5`). Visiting `/`
+  serves a simple web UI, styled via `static/styles.css`, where you can chat with the
+  LLM, pick the difficulty level and see timestamped messages.
    A health check endpoint (`/health`) returns `{"status": "ok"}`.
 
 ## Quick start

--- a/simulator_server/static/index.html
+++ b/simulator_server/static/index.html
@@ -3,29 +3,43 @@
 <head>
 <meta charset="utf-8"/>
 <title>LLM Chat</title>
-<style>
-#chat { border: 1px solid #ccc; padding: 5px; height: 200px; overflow-y: scroll; }
-</style>
+<link rel="stylesheet" href="styles.css"/>
 </head>
 <body>
-<select id="level">
-  <option value="level1">Level 1</option>
-  <option value="level2">Level 2</option>
-  <option value="level3">Level 3</option>
-  <option value="level4">Level 4</option>
-  <option value="level5">Level 5</option>
-</select>
-<div id="chat"></div>
-<input type="text" id="msg" placeholder="Type your message"/>
-<button id="send">Send</button>
+<div id="container">
+  <select id="level">
+    <option value="level1">Level 1</option>
+    <option value="level2">Level 2</option>
+    <option value="level3">Level 3</option>
+    <option value="level4">Level 4</option>
+    <option value="level5">Level 5</option>
+  </select>
+  <div id="chat"></div>
+  <div>
+    <input type="text" id="msg" placeholder="Type your message"/>
+    <button id="send">Send</button>
+  </div>
+</div>
 <script>
+const addMessage = (author, text) => {
+  const chat = document.getElementById('chat');
+  const timestamp = new Date().toLocaleTimeString();
+  chat.innerHTML +=
+    '<div><b>' +
+    author +
+    ':</b> ' +
+    text +
+    ' <span class="timestamp">' +
+    timestamp +
+    '</span></div>';
+};
+
 document.getElementById('send').onclick = async () => {
   const level = document.getElementById('level').value;
   const input = document.getElementById('msg');
   const message = input.value;
   if (!message) return;
-  const chat = document.getElementById('chat');
-  chat.innerHTML += '<div><b>You:</b> ' + message + '</div>';
+  addMessage('You', message);
   input.value = '';
   try {
     const resp = await fetch('/' + level, {
@@ -34,10 +48,10 @@ document.getElementById('send').onclick = async () => {
       body: JSON.stringify({ message })
     });
     const data = await resp.json();
-    chat.innerHTML += '<div><b>LLM:</b> ' + (data.answer || data.error) + '</div>';
-    chat.scrollTop = chat.scrollHeight;
+    addMessage('LLM', data.answer || data.error);
+    document.getElementById('chat').scrollTop = document.getElementById('chat').scrollHeight;
   } catch (err) {
-    chat.innerHTML += '<div><b>Error:</b> ' + err + '</div>';
+    addMessage('Error', err);
   }
 };
 </script>

--- a/simulator_server/static/styles.css
+++ b/simulator_server/static/styles.css
@@ -1,0 +1,40 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f5f5f5;
+  padding: 20px;
+}
+
+#container {
+  max-width: 600px;
+  margin: 0 auto;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 15px;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#chat {
+  border: 1px solid #ddd;
+  padding: 10px;
+  height: 300px;
+  overflow-y: scroll;
+  margin-bottom: 10px;
+  background: #fafafa;
+}
+
+.timestamp {
+  font-size: 0.8em;
+  color: #888;
+  margin-left: 8px;
+}
+
+#msg {
+  width: calc(100% - 80px);
+  padding: 8px;
+  margin-right: 5px;
+}
+
+#send {
+  padding: 8px 16px;
+}


### PR DESCRIPTION
## Summary
- switch chat interface to use `static/styles.css`
- keep timestamps when displaying messages
- note stylesheet usage in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873ab6ccf80832090ce2678548b3e13